### PR TITLE
Renamed duplicate ZeroDivide test

### DIFF
--- a/test/CalculatorFunctions_UnitTest.cpp
+++ b/test/CalculatorFunctions_UnitTest.cpp
@@ -72,7 +72,7 @@ namespace
 	}
 	
 	// Test Calculator class Divide function with zero as numerator
-	TEST(CalculatorTest, ZeroDivide)
+	TEST(CalculatorTest, DivideZero)
 	{
 		EXPECT_EQ(0, Divide(0, 2));
 	}


### PR DESCRIPTION
There were two tests name 'ZeroDivide'. Renamed one of them to 'DivideZero'.